### PR TITLE
[ASUSGAB-1437] Add to DoneXBlock override functionality for staff debug info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def package_data(pkg, roots):
 
 setup(
     name='done-xblock',
-    version='0.1.0-rg',
+    version='0.1.2-rg',
     description='done XBlock',   # TODO: write a better description.
     packages=[
         'done',


### PR DESCRIPTION
**Description:**
* Inherit DoneXblock from ScorableXBlockMixin
* Add flag to display block under specific learner
* Add functionality to handle overrides and rescore

**YouTrack:** https://youtrack.raccoongang.com/issue/ASUSGAB-1437

- [x] Demo is shown to QA

**Notes:**
After performing merge of this issue ping me to create tag with project-version of the xblock